### PR TITLE
Create CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,114 @@
+# Code of Conduct
+
+## 1. Purpose
+A primary goal of our AI for Multiple Long Term Conditions Community is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion.
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+We invite all those who participate in the AIM RSF Community to help us create safe and positive experiences for everyone.
+
+## 2. Open Collaborations in Science
+A supplemental goal of this Code of Conduct is to increase open source literacy, and to foster open collaborations across the AIM Consortia by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society, and especially across the medical domain.
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, please pay it forward. 
+
+## 3. Expected Behaviour
+
+The following behaviors are expected and requested of all community members:
+
+* Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+* Exercise consideration and respect in your speech and actions.
+* Attempt collaboration before conflict.
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.
+* Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+* Demonstrate empathy and kindness toward other people, and be respectful of differing opinions, viewpoints, and experiences. 
+* Treat everything as an opportunity to learn and accept responsibility and apologize to those affected by our mistakes when they occur. 
+* Focus on what is best not just for us as individuals, but for the overall community. 
+
+
+## 4. Unacceptable Behavior
+The following behaviors are considered harassment and are unacceptable within our community:
+* Violence, threats of violence or violent language directed against another person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+* Posting or displaying explicit or violent material.
+* Posting or threatening to post other people's personally identifying information ("doxing").
+* Personal insults and trolling on topics related to gender, sexual orientation, race, religion, or disability. 
+* Public or private harassment towards any members of our community. 
+* Publishing others' private information, such as a physical or email address, without their explicit permission. Please refer to the [Privacy Policy](./PRIVACY_POLICY.md) for more information. 
+* Unwelcome sexual attention. This includes, sexualized comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, and other conduct which could reasonably be considered inappropriate in a professional setting. 
+
+
+## 5. Enforcement Responsibilities
+
+The AIM RSF Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate. 
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. 
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address, speaking on behalf of the AIM RSF, representing the AIM RSF or its activities at a conference or other public setting either online or offline.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+sbatchelor@turing.ac.uk.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. An formal apology may be requested. 
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. Project leaders will be notified and separate meetings may be set reflective of the severity of the behaviour. 
+
+### 3. Ban from Community Events.
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from events, meetings, and forums used by the AI for Multiple Long Term Conditions Research Support Facility (AIM RSF) to support the community. Further involvement in the AIM projects at large will be at the discretion of the individual consortium leaders upon advisement from AIM RSF Community leaders. 
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.


### PR DESCRIPTION
Created code of conduct based on templates provided by GitHub Open Source Community Policy and Mozilla's Code of Conduct.